### PR TITLE
Don't need /usr/local prefix

### DIFF
--- a/plugin/scimark.vim
+++ b/plugin/scimark.vim
@@ -1,4 +1,4 @@
-call scimark#initVariable("g:scimCommand", '/usr/local/bin/sc-im')
+call scimark#initVariable("g:scimCommand", 'sc-im')
 
 function! OpenInScim()
   let lineundercursor=getline('.')


### PR DESCRIPTION
This is a great plugin, but is it commonplace for sc-im users to mandate `/usr/local/bin/sc-im`?